### PR TITLE
Bump `generic-array` minimum version to `0.11.1`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ license = "MIT"
 categories = ["data-structures"]
 
 [dependencies]
-generic-array = "0.11"
+generic-array = "0.11.1"
 num-traits = "0.2.2"
 typenum = "1.9"


### PR DESCRIPTION
Partially fixes #1.

A complete fix should yank numeric-array `0.2.4`, and publish this change as `0.2.5`.